### PR TITLE
Include config.h lines need to be in BGL/*.cc, not BGL/*.hh

### DIFF
--- a/src/BGL/BGLAffine.cc
+++ b/src/BGL/BGLAffine.cc
@@ -7,6 +7,7 @@
 //
 
 
+#include "config.h"
 #include "BGLAffine.hh"
 
 namespace BGL {

--- a/src/BGL/BGLAffine.hh
+++ b/src/BGL/BGLAffine.hh
@@ -11,7 +11,6 @@
 #define BGL_MATRIX_H
 
 #include <math.h>
-#include "config.h"
 
 namespace BGL {
 

--- a/src/BGL/BGLBounds.cc
+++ b/src/BGL/BGLBounds.cc
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "BGLBounds.hh"
 
 namespace BGL {

--- a/src/BGL/BGLCommon.cc
+++ b/src/BGL/BGLCommon.cc
@@ -6,6 +6,7 @@
 //  Copyright 2010 Belfry Software. All rights reserved.
 //
 
+#include "config.h"
 #include "BGLCommon.hh"
 
 

--- a/src/BGL/BGLCommon.hh
+++ b/src/BGL/BGLCommon.hh
@@ -9,8 +9,6 @@
 #ifndef BGL_COMMON_H
 #define BGL_COMMON_H
 
-#include "config.h"
-
 namespace BGL {
 
 

--- a/src/BGL/BGLCompoundRegion.cc
+++ b/src/BGL/BGLCompoundRegion.cc
@@ -6,6 +6,7 @@
 //  Copyright 2010 Belfry Software. All rights reserved.
 //
 
+#include "config.h"
 #include <sstream>
 #include <fstream>
 #include "BGLCommon.hh"

--- a/src/BGL/BGLCompoundRegion.hh
+++ b/src/BGL/BGLCompoundRegion.hh
@@ -10,7 +10,6 @@
 #ifndef BGL_REGION_H
 #define BGL_REGION_H
 
-#include "config.h"
 #include "BGLSimpleRegion.hh"
 #include "BGLPath.hh"
 #include "BGLLine.hh"

--- a/src/BGL/BGLIntersection.cc
+++ b/src/BGL/BGLIntersection.cc
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "BGLIntersection.hh"
 #include "BGLLine.hh"
 

--- a/src/BGL/BGLIntersection.hh
+++ b/src/BGL/BGLIntersection.hh
@@ -10,7 +10,6 @@
 #define BGL_INTERSECTION_H
 
 #include <list>
-#include "config.h"
 #include "BGLCommon.hh"
 #include "BGLPoint.hh"
 

--- a/src/BGL/BGLLine.cc
+++ b/src/BGL/BGLLine.cc
@@ -6,6 +6,7 @@
 //  Copyright 2010 Belfry Software. All rights reserved.
 //
 
+#include "config.h"
 #include "BGLLine.hh"
 
 using namespace std;

--- a/src/BGL/BGLLine.hh
+++ b/src/BGL/BGLLine.hh
@@ -13,7 +13,6 @@
 #include <math.h>
 #include <iostream>
 #include <list>
-#include "config.h"
 #include "BGLCommon.hh"
 #include "BGLAffine.hh"
 #include "BGLIntersection.hh"

--- a/src/BGL/BGLMesh3d.cc
+++ b/src/BGL/BGLMesh3d.cc
@@ -6,6 +6,7 @@
 //  Copyright 2010 Belfry Software. All rights reserved.
 //
 
+#include "config.h"
 #include "BGLMesh3d.hh"
 #include "BGLPoint3d.hh"
 #include "BGLLine.hh"

--- a/src/BGL/BGLMesh3d.hh
+++ b/src/BGL/BGLMesh3d.hh
@@ -10,7 +10,6 @@
 #ifndef BGL_MESH3D_H
 #define BGL_MESH3D_H
 
-#include "config.h"
 #include "BGLPoint3d.hh"
 #include "BGLTriangle3d.hh"
 

--- a/src/BGL/BGLPath.cc
+++ b/src/BGL/BGLPath.cc
@@ -6,6 +6,7 @@
 //  Copyright 2010 Belfry Software. All rights reserved.
 //
 
+#include "config.h"
 #include <iostream>
 #include <iomanip>
 

--- a/src/BGL/BGLPath.hh
+++ b/src/BGL/BGLPath.hh
@@ -10,7 +10,6 @@
 #define BGL_PATH_H
 
 #include <list>
-#include "config.h"
 #include "BGLCommon.hh"
 #include "BGLAffine.hh"
 #include "BGLBounds.hh"

--- a/src/BGL/BGLPoint.cc
+++ b/src/BGL/BGLPoint.cc
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "BGLPoint.hh"
 
 namespace BGL {

--- a/src/BGL/BGLPoint.hh
+++ b/src/BGL/BGLPoint.hh
@@ -12,7 +12,6 @@
 #include <math.h>
 #include <iostream>
 #include <list>
-#include "config.h"
 #include "BGLCommon.hh"
 #include "BGLAffine.hh"
 #include "BGLPoint3d.hh"

--- a/src/BGL/BGLPoint3d.cc
+++ b/src/BGL/BGLPoint3d.cc
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "BGLPoint.hh"
 
 namespace BGL {

--- a/src/BGL/BGLPoint3d.hh
+++ b/src/BGL/BGLPoint3d.hh
@@ -11,7 +11,6 @@
 
 #include <math.h>
 #include <iostream>
-#include "config.h"
 #include "BGLCommon.hh"
 using namespace std;
 

--- a/src/BGL/BGLSVG.cc
+++ b/src/BGL/BGLSVG.cc
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "BGLSVG.hh"
 
 namespace BGL {

--- a/src/BGL/BGLSVG.hh
+++ b/src/BGL/BGLSVG.hh
@@ -10,7 +10,6 @@
 #define BGL_SVG_H
 
 #include <iostream>
-#include "config.h"
 
 using namespace std;
 

--- a/src/BGL/BGLSimpleRegion.cc
+++ b/src/BGL/BGLSimpleRegion.cc
@@ -6,6 +6,7 @@
 //  Copyright 2010 Belfry Software. All rights reserved.
 //
 
+#include "config.h"
 #include "BGLCommon.hh"
 #include "BGLBounds.hh"
 #include "BGLPoint.hh"

--- a/src/BGL/BGLSimpleRegion.hh
+++ b/src/BGL/BGLSimpleRegion.hh
@@ -10,7 +10,6 @@
 #ifndef BGL_SIMPLEREGION_H
 #define BGL_SIMPLEREGION_H
 
-#include "config.h"
 #include "BGLPath.hh"
 #include "BGLLine.hh"
 

--- a/src/BGL/BGLTriangle3d.cc
+++ b/src/BGL/BGLTriangle3d.cc
@@ -6,6 +6,7 @@
 //  Copyright 2010 Belfry Software. All rights reserved.
 //
 
+#include "config.h"
 #include "BGLTriangle3d.hh"
 #include "BGLPoint3d.hh"
 #include "BGLLine.hh"

--- a/src/BGL/BGLTriangle3d.hh
+++ b/src/BGL/BGLTriangle3d.hh
@@ -10,7 +10,6 @@
 #define BGL_TRIANGLE3D_H
 
 #include <list>
-#include "config.h"
 #include "BGLPoint3d.hh"
 #include "BGLLine.hh"
 


### PR DESCRIPTION
The config.h file is only used at library compile time.  When the
include lines are left in the .hh files, the library cannot be linked
to from other projects.  Moving the config.h include lines into the .cc
files resolves this issue.
